### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,6 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
+URL: https://eriqande.github.io/CKMRpop/, https://github.com/eriqande/CKMRpop
+BugReports: https://github.com/eriqande/CKMRpop/issues
 RoxygenNote: 7.2.3


### PR DESCRIPTION
Consider also adding the website link on the top right corner of the gh homepage.

![image](https://github.com/eriqande/CKMRpop/assets/52606734/6ddfe16f-b9d0-44bc-aad2-038d51e91f38)
